### PR TITLE
feat: add async runtime and tensorrt backend

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -66,3 +66,18 @@ vis:
     det: true
     thickness: 2
     font_scale: 0.6
+
+runtime:
+  async:
+    enabled: false
+    capture:
+      queue_size: 4
+      drop_oldest: true
+    infer:
+      workers: 1
+      profile_interval: 60
+    output:
+      queue_size: 2
+    hot_reload:
+      enabled: false
+      watch_interval: 2.0

--- a/main_preview.py
+++ b/main_preview.py
@@ -1,151 +1,344 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Tuple
+
 import cv2
 import numpy as np
-from src.config import load_config
+
+from src.config import load_config, resolve_config_path
+from src.detect import build_detector
+from src.geometry import build_projector, GroundProjector
 from src.io_video.capture import VideoSource
 from src.io_video.fps_meter import FPSMeter
 from src.preprocess import PreprocessPipeline
-from src.detect import build_detector
+from src.runtime import AsyncPipeline, ConfigWatcher, PerfAggregator, RuntimeConfigStore
 from src.track import build_tracker
-from src.geometry import build_projector
 from src.vis import draw_detections
 
-def make_canvas(raw_bgr, proc_bgr, layout="h", divider_px=4,
-                label_raw="RAW", label_proc="PROC", fps=None, show_fps=True):
+
+def make_canvas(
+    raw_bgr: np.ndarray,
+    proc_bgr: np.ndarray,
+    layout: str = "h",
+    divider_px: int = 4,
+    label_raw: str = "RAW",
+    label_proc: str = "PROC",
+    fps: float | None = None,
+    show_fps: bool = True,
+) -> np.ndarray:
     h, w = raw_bgr.shape[:2]
     divider_px = max(0, int(divider_px))
 
-    def put_label(img, org, text, color=(50, 220, 50)):
-        cv2.putText(img, text, org, cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0,0,0), 3, cv2.LINE_AA)
+    def put_label(img: np.ndarray, org: Tuple[int, int], text: str, color=(50, 220, 50)) -> None:
+        cv2.putText(img, text, org, cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 0), 3, cv2.LINE_AA)
         cv2.putText(img, text, org, cv2.FONT_HERSHEY_SIMPLEX, 0.8, color, 2, cv2.LINE_AA)
 
     if layout.lower() == "v":
-        divider = np.full((divider_px, w, 3), (40,40,40), dtype=np.uint8) if divider_px else None
-        canvas = np.vstack([raw_bgr, divider, proc_bgr]) if divider is not None else np.vstack([raw_bgr, proc_bgr])
+        divider = (
+            np.full((divider_px, w, 3), (40, 40, 40), dtype=np.uint8)
+            if divider_px
+            else None
+        )
+        canvas = (
+            np.vstack([raw_bgr, divider, proc_bgr])
+            if divider is not None
+            else np.vstack([raw_bgr, proc_bgr])
+        )
         put_label(canvas, (10, 30), label_raw)
-        put_label(canvas, (10, h + divider_px + 30), label_proc, color=(0,200,255))
+        put_label(canvas, (10, h + divider_px + 30), label_proc, color=(0, 200, 255))
     else:
-        divider = np.full((h, divider_px, 3), (40,40,40), dtype=np.uint8) if divider_px else None
-        canvas = np.hstack([raw_bgr, divider, proc_bgr]) if divider is not None else np.hstack([raw_bgr, proc_bgr])
+        divider = (
+            np.full((h, divider_px, 3), (40, 40, 40), dtype=np.uint8)
+            if divider_px
+            else None
+        )
+        canvas = (
+            np.hstack([raw_bgr, divider, proc_bgr])
+            if divider is not None
+            else np.hstack([raw_bgr, proc_bgr])
+        )
         put_label(canvas, (10, 30), label_raw)
-        put_label(canvas, (w + divider_px + 10, 30), label_proc, color=(0,200,255))
+        put_label(canvas, (w + divider_px + 10, 30), label_proc, color=(0, 200, 255))
 
     if show_fps and fps is not None:
-        put_label(canvas, (10, max(60, h - 10)), f"FPS: {fps:.1f}", color=(0,255,255))
+        put_label(canvas, (10, max(60, h - 10)), f"FPS: {fps:.1f}", color=(0, 255, 255))
     return canvas
 
-def main():
-    cfg = load_config()
 
-    cam_cfg = cfg.get("camera", {})
-    preview_cfg = cfg.get("preview", {})
+def _build_tracker_from_cfg(cfg: dict):
+    track_cfg = cfg.get("tracking", {}) or {}
+    if not track_cfg.get("enabled", False):
+        return None
+    try:
+        return build_tracker(track_cfg)
+    except Exception as exc:
+        print(f"⚠️ 跟踪器初始化失败: {exc}")
+        return None
+
+
+def _build_projector_from_cfg(cfg: dict):
+    geom_cfg = cfg.get("geometry", {}) or {}
+    if not geom_cfg.get("enabled", False):
+        return None
+    try:
+        return build_projector(geom_cfg)
+    except Exception as exc:
+        print(f"⚠️ 几何投影初始化失败: {exc}")
+        return None
+
+
+def _apply_geometry_without_tracker(dets, projector: GroundProjector | None) -> None:
+    if projector is None:
+        return
+    for d in dets:
+        dist = projector.distance_for_bbox((d.x1, d.y1, d.x2, d.y2))
+        if dist is not None:
+            d.distance_m = dist
+
+
+def _extract_preview_cfg(cfg: dict):
+    preview_cfg = cfg.get("preview", {}) or {}
     compare_cfg = preview_cfg.get("compare", {}) or {}
     record_cfg = preview_cfg.get("record", {}) or {}
-    pp_cfg = cfg.get("preprocess", {}) or {}
-    det_cfg = cfg.get("detect", {}) or {}
-    track_cfg = cfg.get("tracking", {}) or {}
-    geom_cfg = cfg.get("geometry", {}) or {}
     vis_cfg = cfg.get("vis", {}) or {}
     draw_cfg = vis_cfg.get("draw", {}) or {}
+    return preview_cfg, compare_cfg, record_cfg, draw_cfg
+
+
+def run_sync(_cfg_file: Path, cfg: dict) -> None:
+    cam_cfg = cfg.get("camera", {}) or {}
+    preview_cfg, compare_cfg, record_cfg, draw_cfg = _extract_preview_cfg(cfg)
+    pp_cfg = cfg.get("preprocess", {}) or {}
+    det_cfg = cfg.get("detect", {}) or {}
 
     vs = VideoSource(
         source=cam_cfg.get("source", 0),
-        width=cam_cfg.get("width", 1280),
-        height=cam_cfg.get("height", 720),
-        fps_request=cam_cfg.get("fps_request", 30),
+        width=int(cam_cfg.get("width", 1280)),
+        height=int(cam_cfg.get("height", 720)),
+        fps_request=int(cam_cfg.get("fps_request", 30)),
         backend=cam_cfg.get("backend", "auto"),
     )
     fpsm = FPSMeter(alpha=0.1)
     pipeline = PreprocessPipeline(pp_cfg)
 
-    detector = None
-    if det_cfg.get("enabled", False):
-        detector = build_detector(det_cfg)
+    detector = build_detector(det_cfg) if det_cfg.get("enabled", False) else None
+    tracker = _build_tracker_from_cfg(cfg)
+    projector = _build_projector_from_cfg(cfg)
 
-    tracker = None
-    if track_cfg.get("enabled", False):
-        try:
-            tracker = build_tracker(track_cfg)
-        except Exception as exc:
-            print(f"⚠️ 跟踪器初始化失败: {exc}")
-            tracker = None
-
-    projector = None
-    if geom_cfg.get("enabled", False):
-        try:
-            projector = build_projector(geom_cfg)
-        except Exception as exc:
-            print(f"⚠️ 几何投影初始化失败: {exc}")
-            projector = None
-
-    # 录像器
-    writer = None
+    writer = None  # TODO: 实现录像输出
     want_record = bool(record_cfg.get("enable", False))
+    if want_record:
+        print("⚠️ 录像输出尚未实现")
     want_compare = bool(compare_cfg.get("enable", True))
     layout = compare_cfg.get("layout", "h")
     divider_px = int(compare_cfg.get("divider_px", 4))
 
-    # 主循环
-    while True:
-        fr = vs.read()
-        if not fr.ok:
-            print("⚠️ 读取失败/视频结束")
-            break
-        raw = fr.image
-        proc = pipeline(raw, ts=fr.ts)
+    try:
+        while True:
+            fr = vs.read()
+            if not fr.ok:
+                print("⚠️ 读取失败/视频结束")
+                break
+            raw = fr.image
+            proc = pipeline(raw.copy(), ts=fr.ts)
 
-        # 检测（在处理后帧上）
-        dets = []
-        if detector is not None:
-            dets = detector.infer(proc)
+            dets = detector.infer(proc) if detector is not None else []
+            if tracker is not None:
+                display_dets = tracker.update(dets, fr.ts, projector=projector)
+            else:
+                display_dets = dets
+                _apply_geometry_without_tracker(display_dets, projector)
 
-        tracked_dets = dets
-        if tracker is not None:
-            tracked_dets = tracker.update(dets, fr.ts, projector=projector)
-        else:
-            if projector is not None:
-                for d in dets:
-                    dist = projector.distance_for_bbox((d.x1, d.y1, d.x2, d.y2))
-                    if dist is not None:
-                        d.distance_m = dist
-        display_dets = tracked_dets
+            if draw_cfg.get("det", True) and display_dets:
+                draw_detections(
+                    proc,
+                    display_dets,
+                    thickness=int(draw_cfg.get("thickness", 2)),
+                    font_scale=float(draw_cfg.get("font_scale", 0.6)),
+                )
 
-        # 叠加绘制
-        if draw_cfg.get("det", True) and display_dets:
-            draw_detections(proc, display_dets,
-                            thickness=int(draw_cfg.get("thickness", 2)),
-                            font_scale=float(draw_cfg.get("font_scale", 0.6)))
+            fps = fpsm.tick(fr.ts)
 
-        fps = fpsm.tick(fr.ts)
+            if want_compare:
+                canvas = make_canvas(
+                    raw,
+                    proc,
+                    layout=layout,
+                    divider_px=divider_px,
+                    label_raw=compare_cfg.get("label_raw", "RAW"),
+                    label_proc=compare_cfg.get("label_proc", "PROC"),
+                    fps=fps,
+                    show_fps=bool(preview_cfg.get("show_fps", True)),
+                )
+                if writer:
+                    writer.write(canvas)
+                cv2.imshow("Compare Preview", canvas)
+            else:
+                frame_disp = proc.copy()
+                if preview_cfg.get("show_fps", True):
+                    cv2.putText(
+                        frame_disp,
+                        f"FPS:{fps:.1f}",
+                        (10, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        1,
+                        (0, 255, 255),
+                        2,
+                    )
+                if writer:
+                    writer.write(frame_disp)
+                cv2.imshow("Preview", frame_disp)
 
-        if want_compare:
-            canvas = make_canvas(
-                raw, proc,
-                layout=layout,
-                divider_px=divider_px,
-                label_raw=compare_cfg.get("label_raw", "RAW"),
-                label_proc=compare_cfg.get("label_proc", "PROC"),
-                fps=fps,
-                show_fps=bool(preview_cfg.get("show_fps", True)),
+            key = cv2.waitKey(1) & 0xFF
+            if key in (27, ord("q")):
+                break
+    finally:
+        if writer:
+            writer.release()
+        if tracker:
+            tracker.close()
+        if detector:
+            detector.close()
+        vs.release()
+        cv2.destroyAllWindows()
+
+
+def run_async(cfg_file: Path, initial_cfg: dict, async_cfg: dict) -> None:
+    store = RuntimeConfigStore(initial_cfg)
+    pipeline = AsyncPipeline(initial_cfg.get("camera", {}) or {}, async_cfg, store)
+    pipeline.start()
+
+    hot_cfg = (async_cfg or {}).get("hot_reload", {}) or {}
+    watcher: ConfigWatcher | None = None
+    if hot_cfg.get("enabled", False):
+        watcher = ConfigWatcher(cfg_file, store, interval=float(hot_cfg.get("watch_interval", 2.0)))
+        watcher.start()
+
+    fpsm = FPSMeter(alpha=0.1)
+    perf = PerfAggregator(pipeline.profile_interval)
+
+    current_version = store.version()
+    cfg = store.get_config()
+    tracker = _build_tracker_from_cfg(cfg)
+    projector = _build_projector_from_cfg(cfg)
+    preview_cfg, compare_cfg, record_cfg, draw_cfg = _extract_preview_cfg(cfg)
+    want_compare = bool(compare_cfg.get("enable", True))
+    layout = compare_cfg.get("layout", "h")
+    divider_px = int(compare_cfg.get("divider_px", 4))
+    want_record = bool(record_cfg.get("enable", False))
+    if want_record:
+        print("⚠️ 录像输出尚未实现")
+    writer = None
+
+    try:
+        while True:
+            packet = pipeline.get_next(timeout=0.2)
+            if packet is None:
+                if pipeline.is_finished():
+                    break
+                continue
+
+            if store.version() != current_version:
+                current_version, cfg = store.snapshot()
+                print("ℹ️ 检测到配置更新，重新初始化组件")
+                if tracker:
+                    tracker.close()
+                tracker = _build_tracker_from_cfg(cfg)
+                projector = _build_projector_from_cfg(cfg)
+                preview_cfg, compare_cfg, record_cfg, draw_cfg = _extract_preview_cfg(cfg)
+                want_compare = bool(compare_cfg.get("enable", True))
+                layout = compare_cfg.get("layout", "h")
+                divider_px = int(compare_cfg.get("divider_px", 4))
+                want_record = bool(record_cfg.get("enable", False))
+                if want_record:
+                    print("⚠️ 录像输出尚未实现")
+
+            detections = packet.detections
+            t0 = time.perf_counter()
+            if tracker is not None:
+                display_dets = tracker.update(detections, packet.timestamp, projector=projector)
+            else:
+                display_dets = detections
+                _apply_geometry_without_tracker(display_dets, projector)
+            track_ms = (time.perf_counter() - t0) * 1000.0
+
+            if draw_cfg.get("det", True) and display_dets:
+                draw_detections(
+                    packet.processed,
+                    display_dets,
+                    thickness=int(draw_cfg.get("thickness", 2)),
+                    font_scale=float(draw_cfg.get("font_scale", 0.6)),
+                )
+
+            fps = fpsm.tick(packet.timestamp)
+
+            perf.update(
+                capture=packet.capture_ms,
+                preprocess=packet.profile.get("preprocess_ms"),
+                detect=packet.profile.get("infer_ms"),
+                track=track_ms,
             )
-            if writer: writer.write(canvas)
-            cv2.imshow("Compare Preview", canvas)
-        else:
-            frame_disp = proc.copy()
-            if preview_cfg.get("show_fps", True):
-                cv2.putText(frame_disp, f"FPS:{fps:.1f}", (10,30),
-                            cv2.FONT_HERSHEY_SIMPLEX, 1, (0,255,255), 2)
-            if writer: writer.write(frame_disp)
-            cv2.imshow("Preview", frame_disp)
+            perf.maybe_log(*pipeline.queue_status())
 
-        key = cv2.waitKey(1) & 0xFF
-        if key in (27, ord('q')):
-            break
+            if want_compare:
+                canvas = make_canvas(
+                    packet.raw,
+                    packet.processed,
+                    layout=layout,
+                    divider_px=divider_px,
+                    label_raw=compare_cfg.get("label_raw", "RAW"),
+                    label_proc=compare_cfg.get("label_proc", "PROC"),
+                    fps=fps,
+                    show_fps=bool(preview_cfg.get("show_fps", True)),
+                )
+                if writer:
+                    writer.write(canvas)
+                cv2.imshow("Compare Preview", canvas)
+            else:
+                frame_disp = packet.processed.copy()
+                if preview_cfg.get("show_fps", True):
+                    cv2.putText(
+                        frame_disp,
+                        f"FPS:{fps:.1f}",
+                        (10, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        1,
+                        (0, 255, 255),
+                        2,
+                    )
+                if writer:
+                    writer.write(frame_disp)
+                cv2.imshow("Preview", frame_disp)
 
-    if writer: writer.release()
-    if tracker: tracker.close()
-    if detector: detector.close()
-    vs.release()
-    cv2.destroyAllWindows()
+            key = cv2.waitKey(1) & 0xFF
+            if key in (27, ord("q")):
+                break
+
+    finally:
+        pipeline.stop()
+        if watcher:
+            watcher.stop()
+            watcher.join(timeout=1.0)
+        if writer:
+            writer.release()
+        if tracker:
+            tracker.close()
+        cv2.destroyAllWindows()
+        if pipeline.capture_error:
+            print(f"⚠️ 采集线程异常: {pipeline.capture_error}")
+
+
+def main(cfg_path: str | None = None) -> None:
+    cfg_file = resolve_config_path(cfg_path)
+    cfg = load_config(str(cfg_file))
+    runtime_cfg = (cfg.get("runtime", {}) or {}).get("async", {}) or {}
+    if runtime_cfg.get("enabled", False):
+        run_async(cfg_file, cfg, runtime_cfg)
+    else:
+        run_sync(cfg_file, cfg)
+
 
 if __name__ == "__main__":
     main()

--- a/src/config.py
+++ b/src/config.py
@@ -68,6 +68,26 @@ _DEFAULTS = {
             "font_scale": 0.6,
         },
     },
+    "runtime": {
+        "async": {
+            "enabled": False,
+            "capture": {
+                "queue_size": 4,
+                "drop_oldest": True,
+            },
+            "infer": {
+                "workers": 1,
+                "profile_interval": 60,
+            },
+            "output": {
+                "queue_size": 2,
+            },
+            "hot_reload": {
+                "enabled": False,
+                "watch_interval": 2.0,
+            },
+        },
+    },
 }
 
 def _merge(a: dict, b: dict):
@@ -88,9 +108,20 @@ def _project_root():
             return p
     return Path.cwd()
 
-def load_config(path: str | None = None) -> dict:
+def resolve_config_path(path: str | None = None) -> Path:
+    """Resolve configuration file path relative to project root."""
     root = _project_root()
-    cfg_path = Path(path) if path else (root / "configs" / "default.yaml")
+    if path:
+        cfg_path = Path(path)
+        if not cfg_path.is_absolute():
+            cfg_path = root / cfg_path
+    else:
+        cfg_path = root / "configs" / "default.yaml"
+    return cfg_path
+
+
+def load_config(path: str | None = None) -> dict:
+    cfg_path = resolve_config_path(path)
     if not cfg_path.exists():
         raise FileNotFoundError(f"配置文件未找到：{cfg_path}")
 

--- a/src/detect/registry.py
+++ b/src/detect/registry.py
@@ -1,9 +1,12 @@
 from typing import Dict, Any
 from .base import Detector
 from .yolo_ultralytics import YOLOUltralytics
+from .yolo_tensorrt import YOLOTensorRT
 
 def build_detector(cfg: Dict[str, Any]) -> Detector:
     backend = (cfg.get("backend") or "ultralytics").lower()
     if backend == "ultralytics":
         return YOLOUltralytics(cfg)
+    if backend == "tensorrt":
+        return YOLOTensorRT(cfg)
     raise ValueError(f"未知检测后端: {backend}")

--- a/src/detect/yolo_tensorrt.py
+++ b/src/detect/yolo_tensorrt.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import cv2
+import numpy as np
+
+from .base import Detector
+from .types import Detection
+
+
+def _nms(boxes: np.ndarray, scores: np.ndarray, threshold: float) -> List[int]:
+    if boxes.size == 0:
+        return []
+    order = scores.argsort()[::-1]
+    keep: List[int] = []
+    while order.size > 0:
+        i = int(order[0])
+        keep.append(i)
+        if order.size == 1:
+            break
+        rest = order[1:]
+        xx1 = np.maximum(boxes[i, 0], boxes[rest, 0])
+        yy1 = np.maximum(boxes[i, 1], boxes[rest, 1])
+        xx2 = np.minimum(boxes[i, 2], boxes[rest, 2])
+        yy2 = np.minimum(boxes[i, 3], boxes[rest, 3])
+
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+        inter = w * h
+        area_i = (boxes[i, 2] - boxes[i, 0]) * (boxes[i, 3] - boxes[i, 1])
+        area_rest = (boxes[rest, 2] - boxes[rest, 0]) * (boxes[rest, 3] - boxes[rest, 1])
+        union = area_i + area_rest - inter
+        iou = np.where(union > 0.0, inter / union, 0.0)
+        idx = np.where(iou <= threshold)[0]
+        order = rest[idx]
+    return keep
+
+
+class YOLOTensorRT(Detector):
+    """TensorRT runtime for YOLO models exported from Ultralytics."""
+
+    def __init__(self, cfg: Dict[str, object]):
+        try:
+            import tensorrt as trt
+        except Exception as exc:  # pragma: no cover - dependency missing
+            raise ImportError(
+                "未安装 TensorRT Python 包，请按照 README 中的 Jetson 指南安装"
+            ) from exc
+
+        try:
+            import pycuda.driver as cuda  # type: ignore
+            import pycuda.autoinit  # type: ignore  # noqa: F401
+        except Exception as exc:  # pragma: no cover - dependency missing
+            raise ImportError("未安装 pycuda，请 pip install pycuda") from exc
+
+        self.trt = trt
+        self.cuda = cuda
+        self.stream = cuda.Stream()
+        self.logger = trt.Logger(trt.Logger.WARNING)
+
+        engine_path = cfg.get("engine")
+        if not engine_path:
+            raise ValueError("detect.engine 未配置 TensorRT engine 路径")
+        engine_file = Path(str(engine_path))
+        if not engine_file.exists():
+            raise FileNotFoundError(f"TensorRT engine 文件不存在: {engine_file}")
+
+        with open(engine_file, "rb") as f:
+            engine_bytes = f.read()
+
+        runtime = trt.Runtime(self.logger)
+        engine = runtime.deserialize_cuda_engine(engine_bytes)
+        if engine is None:
+            raise RuntimeError("TensorRT engine 反序列化失败")
+        context = engine.create_execution_context()
+        if context is None:
+            raise RuntimeError("TensorRT 执行上下文创建失败")
+
+        self.engine = engine
+        self.context = context
+        self.bindings: List[int] = [0] * self.engine.num_bindings
+        self._input_host: Optional[np.ndarray] = None
+        self._input_device = None
+        self._input_shape: Optional[Sequence[int]] = None
+        self._output_specs: List[tuple[int, np.ndarray, object, Sequence[int]]] = []
+        self.input_binding: Optional[int] = None
+        self.input_hw: Optional[tuple[int, int]] = None
+
+        self._setup_bindings(cfg)
+
+        self.conf = float(cfg.get("conf_thres", 0.25))
+        self.iou = float(cfg.get("iou_thres", 0.7))
+        self.max_det = int(cfg.get("max_det", 100))
+        keep = cfg.get("classes_keep", []) or []
+        self.keep = {int(x) for x in keep}
+        names_cfg = cfg.get("names")
+        if isinstance(names_cfg, dict):
+            self.names = {int(k): str(v) for k, v in names_cfg.items()}
+        elif isinstance(names_cfg, list):
+            self.names = {i: str(v) for i, v in enumerate(names_cfg)}
+        else:
+            self.names = {}
+        self.num_classes = int(cfg.get("num_classes", len(self.names) or 80))
+        if not self.names:
+            self.names = {i: str(i) for i in range(self.num_classes)}
+        self._has_obj_conf: Optional[bool] = (
+            bool(cfg["has_obj_conf"]) if "has_obj_conf" in cfg else None
+        )
+
+    def _setup_bindings(self, cfg: Dict[str, object]) -> None:
+        trt = self.trt
+        input_hw_cfg = cfg.get("input_hw")
+        if input_hw_cfg is not None:
+            if not isinstance(input_hw_cfg, (list, tuple)) or len(input_hw_cfg) != 2:
+                raise ValueError("input_hw 需要形如 [height, width]")
+            input_hw = (int(input_hw_cfg[0]), int(input_hw_cfg[1]))
+        else:
+            input_hw = None
+
+        # Configure input binding first
+        for idx in range(self.engine.num_bindings):
+            if not self.engine.binding_is_input(idx):
+                continue
+            dtype = np.dtype(trt.nptype(self.engine.get_binding_dtype(idx)))
+            shape = list(self.engine.get_binding_shape(idx))
+            if any(dim == -1 for dim in shape):
+                if input_hw is None:
+                    raise ValueError(
+                        "TensorRT engine 为动态 shape，请在配置中提供 input_hw: [height, width]"
+                    )
+                shape = [1, 3, int(input_hw[0]), int(input_hw[1])]
+                self.context.set_binding_shape(idx, tuple(shape))
+            self._input_shape = tuple(shape)
+            size = int(math.prod(shape))
+            host_mem = self.cuda.pagelocked_empty(size, dtype=dtype)
+            device_mem = self.cuda.mem_alloc(host_mem.nbytes)
+            self._input_host = host_mem
+            self._input_device = device_mem
+            self.bindings[idx] = int(device_mem)
+            self.input_binding = idx
+            self.input_hw = (shape[2], shape[3])
+            break
+
+        if self.input_binding is None:
+            raise RuntimeError("未找到 TensorRT 输入 binding")
+
+        # Output bindings
+        for idx in range(self.engine.num_bindings):
+            if self.engine.binding_is_input(idx):
+                continue
+            dtype = np.dtype(trt.nptype(self.engine.get_binding_dtype(idx)))
+            shape = tuple(self.context.get_binding_shape(idx))
+            if any(dim == -1 for dim in shape):
+                raise RuntimeError("TensorRT 输出 shape 未固定，请重新导出 engine")
+            size = int(math.prod(shape))
+            host_mem = self.cuda.pagelocked_empty(size, dtype=dtype)
+            device_mem = self.cuda.mem_alloc(host_mem.nbytes)
+            self.bindings[idx] = int(device_mem)
+            self._output_specs.append((idx, host_mem, device_mem, shape))
+
+    def _preprocess(self, image: np.ndarray) -> tuple[np.ndarray, Dict[str, float]]:
+        if self.input_hw is None:
+            raise RuntimeError("TensorRT 输入尺寸未初始化")
+        input_h, input_w = self.input_hw
+        h, w = image.shape[:2]
+        scale = min(input_w / w, input_h / h)
+        new_w = int(round(w * scale))
+        new_h = int(round(h * scale))
+        resized = cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+        canvas = np.full((input_h, input_w, 3), 114, dtype=np.uint8)
+        top = (input_h - new_h) // 2
+        left = (input_w - new_w) // 2
+        canvas[top : top + new_h, left : left + new_w, :] = resized
+        canvas = cv2.cvtColor(canvas, cv2.COLOR_BGR2RGB)
+        tensor = canvas.astype(np.float32) / 255.0
+        tensor = np.transpose(tensor, (2, 0, 1))
+        tensor = np.expand_dims(tensor, 0)
+        return np.ascontiguousarray(tensor, dtype=np.float32), {
+            "scale": scale,
+            "pad_x": float(left),
+            "pad_y": float(top),
+            "orig_h": float(h),
+            "orig_w": float(w),
+        }
+
+    def _flatten_predictions(self, pred: np.ndarray) -> np.ndarray:
+        if pred.ndim == 3:
+            if pred.shape[1] > pred.shape[2]:
+                pred = np.transpose(pred, (0, 2, 1))
+            pred = pred[0]
+        elif pred.ndim == 2:
+            pass
+        else:
+            raise ValueError("不支持的 TensorRT 输出维度")
+        return np.ascontiguousarray(pred)
+
+    def _postprocess(self, pred: np.ndarray, meta: Dict[str, float]) -> List[Detection]:
+        pred = self._flatten_predictions(pred)
+        if pred.size == 0:
+            return []
+        num_attrs = pred.shape[1]
+        if num_attrs < 6:
+            return []
+
+        has_obj = self._has_obj_conf
+        if has_obj is None:
+            if num_attrs - 5 == self.num_classes:
+                has_obj = True
+            elif num_attrs - 4 == self.num_classes:
+                has_obj = False
+            elif num_attrs - 5 > 0:
+                has_obj = True
+            else:
+                has_obj = False
+            self._has_obj_conf = has_obj
+
+        if has_obj:
+            class_scores = pred[:, 5:]
+            objectness = pred[:, 4:5]
+            scores_matrix = class_scores * objectness
+        else:
+            class_scores = pred[:, 4:]
+            scores_matrix = class_scores
+
+        num_classes = scores_matrix.shape[1]
+        if self.keep:
+            valid_classes = [c for c in sorted(self.keep) if 0 <= c < num_classes]
+        else:
+            valid_classes = list(range(num_classes))
+        if not valid_classes:
+            return []
+
+        selected_scores = scores_matrix[:, valid_classes]
+        cls_indices = np.argmax(selected_scores, axis=1)
+        confidences = selected_scores[np.arange(selected_scores.shape[0]), cls_indices]
+        mask = confidences >= self.conf
+        if not np.any(mask):
+            return []
+
+        selected_scores = confidences[mask]
+        cls_indices = cls_indices[mask]
+        pred = pred[mask]
+        boxes = np.zeros((pred.shape[0], 4), dtype=np.float32)
+        boxes[:, 0] = pred[:, 0] - 0.5 * pred[:, 2]
+        boxes[:, 1] = pred[:, 1] - 0.5 * pred[:, 3]
+        boxes[:, 2] = pred[:, 0] + 0.5 * pred[:, 2]
+        boxes[:, 3] = pred[:, 1] + 0.5 * pred[:, 3]
+
+        scale = meta["scale"]
+        pad_x = meta["pad_x"]
+        pad_y = meta["pad_y"]
+        orig_w = meta["orig_w"]
+        orig_h = meta["orig_h"]
+        boxes[:, [0, 2]] = (boxes[:, [0, 2]] - pad_x) / max(1e-6, scale)
+        boxes[:, [1, 3]] = (boxes[:, [1, 3]] - pad_y) / max(1e-6, scale)
+        boxes[:, 0] = np.clip(boxes[:, 0], 0, orig_w - 1)
+        boxes[:, 1] = np.clip(boxes[:, 1], 0, orig_h - 1)
+        boxes[:, 2] = np.clip(boxes[:, 2], 0, orig_w - 1)
+        boxes[:, 3] = np.clip(boxes[:, 3], 0, orig_h - 1)
+
+        detections: List[Detection] = []
+        for cls in set(int(valid_classes[idx]) for idx in cls_indices):
+            mask_cls = [i for i, c in enumerate(cls_indices) if int(valid_classes[c]) == cls]
+            if not mask_cls:
+                continue
+            cls_boxes = boxes[mask_cls]
+            cls_scores = selected_scores[mask_cls]
+            keep_idx = _nms(cls_boxes, cls_scores, self.iou)
+            for idx in keep_idx:
+                global_idx = mask_cls[idx]
+                cls_id = int(valid_classes[cls_indices[global_idx]])
+                name = self.names.get(cls_id, str(cls_id))
+                box = boxes[global_idx]
+                detections.append(
+                    Detection(
+                        float(box[0]),
+                        float(box[1]),
+                        float(box[2]),
+                        float(box[3]),
+                        float(selected_scores[global_idx]),
+                        cls_id,
+                        name,
+                    )
+                )
+
+        if len(detections) > self.max_det:
+            detections.sort(key=lambda d: d.conf, reverse=True)
+            detections = detections[: self.max_det]
+        return detections
+
+    def infer(self, bgr: np.ndarray) -> List[Detection]:
+        if self._input_host is None or self._input_device is None:
+            raise RuntimeError("TensorRT 输入缓冲区未初始化")
+        tensor, meta = self._preprocess(bgr)
+        np.copyto(self._input_host, tensor.reshape(-1))
+        self.cuda.memcpy_htod_async(self._input_device, self._input_host, self.stream)
+        self.context.execute_async_v2(bindings=self.bindings, stream_handle=self.stream.handle)
+        outputs: List[np.ndarray] = []
+        for _, host_mem, device_mem, shape in self._output_specs:
+            self.cuda.memcpy_dtoh_async(host_mem, device_mem, self.stream)
+            outputs.append(host_mem.reshape(shape))
+        self.stream.synchronize()
+        if not outputs:
+            return []
+        return self._postprocess(outputs[0], meta)
+
+    def close(self) -> None:
+        try:
+            for _, _, device_mem, _ in self._output_specs:
+                device_mem.free()
+        except Exception:
+            pass
+        if self._input_device is not None:
+            try:
+                self._input_device.free()
+            except Exception:
+                pass
+        self._output_specs.clear()
+        self._input_host = None
+        self._input_device = None
+        self.context = None
+        self.engine = None
+
+
+__all__ = ["YOLOTensorRT"]

--- a/src/io_video/capture.py
+++ b/src/io_video/capture.py
@@ -1,24 +1,74 @@
-import cv2, time
+from __future__ import annotations
 
+from dataclasses import dataclass
+import time
+from typing import Any
+
+import cv2
+
+
+@dataclass(slots=True)
 class Frame:
-    __slots__ = ("ok","image","ts")
-    def __init__(self, ok, image, ts):
-        self.ok = ok
-        self.image = image
-        self.ts = ts  # 捕获时间戳（秒，float）
+    ok: bool
+    image: Any
+    ts: float  # 捕获时间戳（秒，float）
+
+
+def _looks_like_gstreamer(source: Any) -> bool:
+    if not isinstance(source, str):
+        return False
+    tokens = source.strip().split()
+    if not tokens:
+        return False
+    head = tokens[0]
+    return "!" in source or head.startswith("nvarguscamerasrc") or head.startswith("v4l2src")
+
 
 class VideoSource:
     def __init__(self, source=0, width=1280, height=720, fps_request=30, backend="auto"):
-        # 先用 OpenCV 标准接口；后续可在 backend=="gstreamer" 替换
-        self.cap = cv2.VideoCapture(source)
-        self.cap.set(cv2.CAP_PROP_FRAME_WIDTH,  width)
-        self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
-        self.cap.set(cv2.CAP_PROP_FPS,         fps_request)
+        self.source = source
+        self.backend = (backend or "auto").lower()
+        self.cap = None
+        self._backend_used = None
+        self._open(width, height, fps_request)
+
+    def _open(self, width: int, height: int, fps_request: int) -> None:
+        prefer_gst = self.backend == "gstreamer" or (
+            self.backend == "auto" and _looks_like_gstreamer(self.source)
+        )
+
+        cap = None
+        backend_used = None
+
+        if prefer_gst:
+            cap = cv2.VideoCapture(self.source, cv2.CAP_GSTREAMER)
+            backend_used = "gstreamer"
+            if not cap.isOpened() and self.backend == "auto":
+                cap.release()
+                cap = None
+
+        if cap is None:
+            cap = cv2.VideoCapture(self.source)
+            backend_used = "default"
+
+        if not cap or not cap.isOpened():
+            raise RuntimeError(f"无法打开视频源: {self.source}")
+
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        cap.set(cv2.CAP_PROP_FPS, fps_request)
+
+        self.cap = cap
+        self._backend_used = backend_used
 
     def read(self) -> Frame:
+        if not self.cap:
+            raise RuntimeError("VideoSource 尚未初始化")
         ok, img = self.cap.read()
         ts = time.time()
         return Frame(ok, img, ts)
 
     def release(self):
-        if self.cap: self.cap.release()
+        if self.cap:
+            self.cap.release()
+            self.cap = None

--- a/src/runtime/__init__.py
+++ b/src/runtime/__init__.py
@@ -1,0 +1,10 @@
+from .async_pipeline import AsyncPipeline, InferencePacket, PerfAggregator
+from .config import ConfigWatcher, RuntimeConfigStore
+
+__all__ = [
+    "AsyncPipeline",
+    "InferencePacket",
+    "PerfAggregator",
+    "ConfigWatcher",
+    "RuntimeConfigStore",
+]

--- a/src/runtime/async_pipeline.py
+++ b/src/runtime/async_pipeline.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ..detect import Detection, build_detector
+from ..io_video.capture import VideoSource
+from ..preprocess import PreprocessPipeline
+from .config import RuntimeConfigStore
+
+
+@dataclass(slots=True)
+class FramePacket:
+    seq_id: int
+    image: np.ndarray
+    timestamp: float
+    capture_ms: float
+
+
+@dataclass(slots=True)
+class InferencePacket:
+    seq_id: int
+    timestamp: float
+    raw: np.ndarray
+    processed: np.ndarray
+    detections: List[Detection]
+    capture_ms: float
+    profile: Dict[str, float]
+
+
+class _CaptureThread(threading.Thread):
+    def __init__(
+        self,
+        camera_cfg: dict,
+        frame_queue: queue.Queue,
+        stop_event: threading.Event,
+        drop_oldest: bool,
+        num_consumers: int,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._camera_cfg = camera_cfg
+        self._queue = frame_queue
+        self._stop_event = stop_event
+        self._drop_oldest = drop_oldest
+        self._num_consumers = num_consumers
+        self.error: Optional[Exception] = None
+
+    def request_stop(self) -> None:
+        self._stop_event.set()
+
+    def _open_source(self) -> VideoSource:
+        cfg = self._camera_cfg or {}
+        return VideoSource(
+            source=cfg.get("source", 0),
+            width=int(cfg.get("width", 1280)),
+            height=int(cfg.get("height", 720)),
+            fps_request=int(cfg.get("fps_request", 30)),
+            backend=cfg.get("backend", "auto"),
+        )
+
+    def run(self) -> None:  # pragma: no cover - background thread
+        seq_id = 0
+        source: Optional[VideoSource] = None
+        try:
+            source = self._open_source()
+            while not self._stop_event.is_set():
+                t0 = time.perf_counter()
+                frame = source.read()
+                capture_ms = (time.perf_counter() - t0) * 1000.0
+                if not frame.ok:
+                    break
+                packet = FramePacket(
+                    seq_id=seq_id,
+                    image=frame.image,
+                    timestamp=frame.ts,
+                    capture_ms=capture_ms,
+                )
+                seq_id += 1
+                while not self._stop_event.is_set():
+                    try:
+                        self._queue.put(packet, timeout=0.05)
+                        break
+                    except queue.Full:
+                        if not self._drop_oldest:
+                            continue
+                        try:
+                            dropped = self._queue.get_nowait()
+                            if dropped is None:
+                                # Sentinel from stop(), requeue it
+                                self._queue.put_nowait(None)
+                        except queue.Empty:
+                            pass
+        except Exception as exc:  # pragma: no cover - log and propagate later
+            self.error = exc
+        finally:
+            if source is not None:
+                source.release()
+            for _ in range(self._num_consumers):
+                try:
+                    self._queue.put_nowait(None)
+                except queue.Full:
+                    while True:
+                        try:
+                            self._queue.get_nowait()
+                        except queue.Empty:
+                            break
+                    self._queue.put(None)
+
+
+class _InferWorker(threading.Thread):
+    def __init__(
+        self,
+        worker_id: int,
+        frame_queue: queue.Queue,
+        output_queue: queue.Queue,
+        stop_event: threading.Event,
+        config_store: RuntimeConfigStore,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.worker_id = worker_id
+        self._frame_queue = frame_queue
+        self._output_queue = output_queue
+        self._stop_event = stop_event
+        self._config_store = config_store
+        self._pipeline: Optional[PreprocessPipeline] = None
+        self._detector = None
+        self._local_version = -1
+
+    def _close_modules(self) -> None:
+        if self._detector is not None:
+            try:
+                self._detector.close()
+            except Exception:
+                pass
+            self._detector = None
+        self._pipeline = None
+
+    def _rebuild(self, cfg: dict) -> None:
+        self._close_modules()
+        pp_cfg = cfg.get("preprocess", {}) or {}
+        det_cfg = cfg.get("detect", {}) or {}
+        self._pipeline = PreprocessPipeline(pp_cfg)
+        if det_cfg.get("enabled", False):
+            self._detector = build_detector(det_cfg)
+        else:
+            self._detector = None
+
+    def run(self) -> None:  # pragma: no cover - background thread
+        try:
+            while not self._stop_event.is_set():
+                if self._local_version != self._config_store.version():
+                    version, cfg = self._config_store.snapshot()
+                    try:
+                        self._rebuild(cfg)
+                    except Exception as exc:
+                        print(f"⚠️ Worker{self.worker_id} 重建失败: {exc}")
+                        time.sleep(0.5)
+                        continue
+                    self._local_version = version
+
+                try:
+                    packet = self._frame_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if packet is None:
+                    self._output_queue.put(None)
+                    break
+
+                raw = packet.image
+                proc = raw.copy()
+                profile = {"preprocess_ms": 0.0, "infer_ms": 0.0}
+
+                t0 = time.perf_counter()
+                if self._pipeline is not None:
+                    try:
+                        proc = self._pipeline(proc, ts=packet.timestamp)
+                    except Exception as exc:
+                        print(f"⚠️ 预处理失败: {exc}")
+                        proc = raw.copy()
+                t1 = time.perf_counter()
+
+                dets: List[Detection] = []
+                if self._detector is not None:
+                    try:
+                        dets = self._detector.infer(proc)
+                    except Exception as exc:
+                        print(f"⚠️ 推理失败: {exc}")
+                        dets = []
+                t2 = time.perf_counter()
+
+                profile["preprocess_ms"] = (t1 - t0) * 1000.0
+                profile["infer_ms"] = (t2 - t1) * 1000.0
+
+                self._output_queue.put(
+                    InferencePacket(
+                        seq_id=packet.seq_id,
+                        timestamp=packet.timestamp,
+                        raw=raw,
+                        processed=proc,
+                        detections=dets,
+                        capture_ms=packet.capture_ms,
+                        profile=profile,
+                    )
+                )
+        finally:
+            self._close_modules()
+
+
+class PerfAggregator:
+    def __init__(self, interval: int = 60) -> None:
+        self.interval = max(1, int(interval))
+        self.reset()
+
+    def reset(self) -> None:
+        self.count = 0
+        self.capture_ms = 0.0
+        self.preprocess_ms = 0.0
+        self.detect_ms = 0.0
+        self.track_ms = 0.0
+
+    def update(
+        self,
+        capture: Optional[float] = None,
+        preprocess: Optional[float] = None,
+        detect: Optional[float] = None,
+        track: Optional[float] = None,
+    ) -> None:
+        self.count += 1
+        if capture is not None:
+            self.capture_ms += capture
+        if preprocess is not None:
+            self.preprocess_ms += preprocess
+        if detect is not None:
+            self.detect_ms += detect
+        if track is not None:
+            self.track_ms += track
+
+    def maybe_log(
+        self,
+        queue_in: Tuple[int, int],
+        queue_out: Tuple[int, int],
+    ) -> None:
+        if self.count < self.interval:
+            return
+        denom = max(1, self.count)
+        avg_capture = self.capture_ms / denom
+        avg_pre = self.preprocess_ms / denom
+        avg_det = self.detect_ms / denom
+        avg_track = self.track_ms / denom
+        qi, qim = queue_in
+        qo, qom = queue_out
+        print(
+            f"[Perf] capture={avg_capture:.1f}ms preprocess={avg_pre:.1f}ms "
+            f"detect={avg_det:.1f}ms track={avg_track:.1f}ms "
+            f"queue_in={qi}/{qim} queue_out={qo}/{qom}"
+        )
+        self.reset()
+
+
+class AsyncPipeline:
+    def __init__(
+        self,
+        camera_cfg: dict,
+        async_cfg: dict,
+        config_store: RuntimeConfigStore,
+    ) -> None:
+        self._stop_event = threading.Event()
+        capture_cfg = (async_cfg or {}).get("capture", {}) or {}
+        infer_cfg = (async_cfg or {}).get("infer", {}) or {}
+        output_cfg = (async_cfg or {}).get("output", {}) or {}
+
+        capture_queue_size = max(1, int(capture_cfg.get("queue_size", 4)))
+        output_queue_size = max(1, int(output_cfg.get("queue_size", 2)))
+        self.frame_queue: queue.Queue = queue.Queue(maxsize=capture_queue_size)
+        self.output_queue: queue.Queue = queue.Queue(maxsize=output_queue_size)
+
+        self._workers_num = max(1, int(infer_cfg.get("workers", 1)))
+        self.profile_interval = max(1, int(infer_cfg.get("profile_interval", 60)))
+
+        drop_oldest = bool(capture_cfg.get("drop_oldest", True))
+        self._capture_thread = _CaptureThread(
+            camera_cfg=camera_cfg,
+            frame_queue=self.frame_queue,
+            stop_event=self._stop_event,
+            drop_oldest=drop_oldest,
+            num_consumers=self._workers_num,
+        )
+
+        self._workers = [
+            _InferWorker(i, self.frame_queue, self.output_queue, self._stop_event, config_store)
+            for i in range(self._workers_num)
+        ]
+
+        self._buffer: Dict[int, InferencePacket] = {}
+        self._expected_seq = 0
+        self._active_workers = self._workers_num
+        self._finished = False
+
+    def start(self) -> None:
+        self._capture_thread.start()
+        for worker in self._workers:
+            worker.start()
+
+    def stop(self) -> None:
+        if self._stop_event.is_set():
+            return
+        self._stop_event.set()
+        self._capture_thread.request_stop()
+        for _ in range(self._workers_num):
+            try:
+                self.frame_queue.put_nowait(None)
+            except queue.Full:
+                pass
+        self._capture_thread.join(timeout=2.0)
+        for worker in self._workers:
+            worker.join(timeout=2.0)
+        self._finished = True
+        while not self.output_queue.empty():
+            try:
+                self.output_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.output_queue.put(None)
+
+    def is_finished(self) -> bool:
+        return self._finished and not self._buffer
+
+    def get_next(self, timeout: float = 0.2) -> Optional[InferencePacket]:
+        if self.is_finished():
+            return None
+
+        while True:
+            buffered = self._buffer.pop(self._expected_seq, None)
+            if buffered is not None:
+                self._expected_seq += 1
+                return buffered
+
+            if self._finished:
+                return None
+
+            try:
+                item = self.output_queue.get(timeout=timeout)
+            except queue.Empty:
+                if self._stop_event.is_set() and self._active_workers == 0:
+                    self._finished = True
+                return None
+
+            if item is None:
+                self._active_workers -= 1
+                if self._active_workers <= 0:
+                    self._finished = True
+                continue
+
+            self._buffer[item.seq_id] = item
+
+    def queue_status(self) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        return (
+            (self.frame_queue.qsize(), self.frame_queue.maxsize),
+            (self.output_queue.qsize(), self.output_queue.maxsize),
+        )
+
+    @property
+    def capture_error(self) -> Optional[Exception]:
+        return self._capture_thread.error
+
+
+__all__ = ["AsyncPipeline", "InferencePacket", "PerfAggregator"]

--- a/src/runtime/config.py
+++ b/src/runtime/config.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import threading
+import time
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable, Optional
+
+from ..config import load_config, resolve_config_path
+
+
+class RuntimeConfigStore:
+    """Thread-safe store that keeps the latest configuration snapshot."""
+
+    def __init__(self, initial_cfg: dict) -> None:
+        self._lock = threading.Lock()
+        self._cfg = deepcopy(initial_cfg)
+        self._version = 0
+
+    def snapshot(self) -> tuple[int, dict]:
+        """Return a deep-copied configuration with its version."""
+        with self._lock:
+            return self._version, deepcopy(self._cfg)
+
+    def version(self) -> int:
+        with self._lock:
+            return self._version
+
+    def get_config(self) -> dict:
+        with self._lock:
+            return deepcopy(self._cfg)
+
+    def update(self, cfg: dict) -> int:
+        with self._lock:
+            self._cfg = deepcopy(cfg)
+            self._version += 1
+            return self._version
+
+
+class ConfigWatcher(threading.Thread):
+    """Watch a configuration file and push updates to :class:`RuntimeConfigStore`."""
+
+    def __init__(
+        self,
+        path: str | Path | None,
+        store: RuntimeConfigStore,
+        interval: float = 2.0,
+        loader: Optional[Callable[[str | Path], dict]] = None,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._store = store
+        self._interval = max(0.2, float(interval))
+        self._stop_event = threading.Event()
+        self._loader = loader or (lambda p: load_config(str(p)))
+        self._path = resolve_config_path(path)
+        self._last_mtime: Optional[float] = None
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:  # pragma: no cover - background thread
+        while not self._stop_event.is_set():
+            try:
+                stat = Path(self._path).stat()
+                mtime = float(stat.st_mtime)
+            except FileNotFoundError:
+                mtime = None
+
+            if mtime is not None and self._last_mtime is None:
+                self._last_mtime = mtime
+            elif (
+                mtime is not None
+                and self._last_mtime is not None
+                and mtime > self._last_mtime + 1e-3
+            ):
+                try:
+                    cfg = self._loader(self._path)
+                except Exception as exc:  # pragma: no cover - best effort logging
+                    print(f"⚠️ 配置重载失败: {exc}")
+                else:
+                    self._store.update(cfg)
+                    self._last_mtime = mtime
+            time.sleep(self._interval)
+
+
+__all__ = ["RuntimeConfigStore", "ConfigWatcher"]


### PR DESCRIPTION
## Summary
- implement an asynchronous capture/inference/display pipeline with hot reload support in `main_preview.py`
- add runtime helpers for configuration watching and queue-based workers while extending defaults/configs for async tuning
- support GStreamer video capture and a TensorRT YOLO backend for Jetson deployment

## Testing
- python -m compileall src main_preview.py

------
https://chatgpt.com/codex/tasks/task_e_68cea5ea3ea8832a9d3537846209a833